### PR TITLE
Monobehaviour-based GraphModel

### DIFF
--- a/Editor/Controllers/GraphController.cs
+++ b/Editor/Controllers/GraphController.cs
@@ -410,7 +410,6 @@ namespace NewGraph {
         /// </summary>
         /// <param name="graphData"></param>
         private void Load(GraphModel graphData) {
-
             // return early if we are already in the process of loading a graph...
             if (isLoading) {
                 return;
@@ -431,11 +430,13 @@ namespace NewGraph {
             // offload the actual loading to the next frame...
             graphView.schedule.Execute(() => {
                 this.graphData = graphData;
+
                 this.graphData.CreateSerializedObject();
 
+#if !NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
                 // remember that this is our currently opened graph...
                 GraphSettings.LastOpenedGraphModel = graphData;
-
+#endif
                 // update the viewport to the last saved location
                 if (graphData.ViewportInitiallySet) {
                     graphView.UpdateViewTransform(graphData.ViewPosition, graphData.ViewScale);

--- a/Editor/Controllers/InspectorController.cs
+++ b/Editor/Controllers/InspectorController.cs
@@ -39,6 +39,7 @@ namespace NewGraph {
 
             inspectorContainer = parent.Q<VisualElement>(nameof(inspectorContainer));
 
+#if !NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
             createButton = commandPanel.Q<Button>(nameof(createButton));
             createButton.clicked += CreateButtonClicked;
             createButton.Add(GraphSettings.CreateButtonIcon);
@@ -52,7 +53,7 @@ namespace NewGraph {
             loadButton = commandPanel.Q<Button>(nameof(loadButton));
             loadButton.clicked += LoadButtonClicked;
             loadButton.Add(GraphSettings.LoadButtonIcon);
-
+#endif
             homeButton = commandPanel.Q<Button>(nameof(homeButton));
             homeButton.clicked += HomeButtonClicked;
             homeButton.Add(GraphSettings.HomeButtonIcon);
@@ -62,7 +63,7 @@ namespace NewGraph {
             inspectorButtonImage = new Image();
             inspectorButton.Add(inspectorButtonImage);
             inspectorHeader = inspectorRoot.Q<VisualElement>(nameof(inspectorHeader));
-
+            
             Label startLabel = new Label(Settings.noGraphLoadedLabel);
             startLabel.AddToClassList(nameof(startLabel));
 
@@ -72,6 +73,13 @@ namespace NewGraph {
 
             SetSelectedNodeInfoActive();
             SetInspectorVisibility(EditorPrefs.GetBool(GraphSettings.isInspectorVisiblePrefsKey, isInspectorVisible));
+            
+#if NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
+            createButton = commandPanel.Q<Button>(nameof(createButton));
+            createButton.style.display = DisplayStyle.None;
+            loadButton = commandPanel.Q<Button>(nameof(loadButton));
+            loadButton.style.display = DisplayStyle.None;
+#endif
         }
 
         private void SetInspectorVisibility(bool visible=true) {
@@ -164,18 +172,13 @@ namespace NewGraph {
             }
         }
          
+#if !NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
         /// <summary>
         /// called when the create button was clicked.
         /// </summary>
         private void CreateButtonClicked() {
             OnCreateButtonClicked?.Invoke();
-
-#if NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
-            GameObject newGraph = new GameObject { name = "New Graph" };
-            T graphData = newGraph.AddComponent<T>();
-            CreateRenameGraphUI(graphData);
-            Clear();
-#else
+        
             string fileEnding = "asset";
 
             // retrieve the last opened folder
@@ -212,9 +215,9 @@ namespace NewGraph {
                 Clear();
                 OnAfterGraphCreated?.Invoke(graphData);
             }
-#endif 
-        }
 
+        }
+#endif 
         /// <summary>
         /// Resets the current insepctor content.
         /// </summary>
@@ -228,7 +231,10 @@ namespace NewGraph {
         /// </summary>
         /// <param name="graph">The graph that renaming should operate on</param>
         public void CreateRenameGraphUI(T graph) {
-
+#if NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
+            Label graphName = inspectorHeader.Q<Label>();
+            graphName.text = graph.name;
+#else
             // avoid some redudancy when setting string property...
             void SetStringValueAndApply(SerializedProperty prop, string otherValue) {
                 prop.stringValue = otherValue;
@@ -289,6 +295,7 @@ namespace NewGraph {
                     SetStringValueAndApply(tmpNameProperty, originalName);
                 }
             });
+#endif
         }
 
         /// <summary>
@@ -297,7 +304,7 @@ namespace NewGraph {
         private void HomeButtonClicked() {
             OnHomeClicked?.Invoke();
         }
-
+#if !NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
         /*
         /// <summary>
         /// Called when the save button was clicked.
@@ -316,7 +323,7 @@ namespace NewGraph {
             pickerActive = true;
             OnLoadClicked?.Invoke();
         }
-
+#endif
         /// <summary>
         /// IMGUI draw method to display the object picker popup
         /// </summary>

--- a/Editor/Controllers/InspectorController.cs
+++ b/Editor/Controllers/InspectorController.cs
@@ -170,6 +170,12 @@ namespace NewGraph {
         private void CreateButtonClicked() {
             OnCreateButtonClicked?.Invoke();
 
+#if NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
+            GameObject newGraph = new GameObject { name = "New Graph" };
+            T graphData = newGraph.AddComponent<T>();
+            CreateRenameGraphUI(graphData);
+            Clear();
+#else
             string fileEnding = "asset";
 
             // retrieve the last opened folder
@@ -201,11 +207,12 @@ namespace NewGraph {
 
                 AssetDatabase.CreateAsset(graphData, path);
                 AssetDatabase.SaveAssets();
+               
                 CreateRenameGraphUI(graphData);
                 Clear();
-
                 OnAfterGraphCreated?.Invoke(graphData);
             }
+#endif 
         }
 
         /// <summary>

--- a/Editor/Settings/GraphSettings.cs
+++ b/Editor/Settings/GraphSettings.cs
@@ -11,9 +11,13 @@ namespace NewGraph {
         public const string assetGUID = "015778251503b3c44a2b9dfc3a36ad10";
         public const string menuItemBase = "Tools/";
         public const string debugDefine = "TOOLS_DEBUG";
-        public const string lastOpenedGraphEditorPrefsKey = nameof(NewGraph) + "." + nameof(GraphSettingsAsset) + "." + nameof(lastOpenedGraphEditorPrefsKey);
         public const string lastOpenedDirectoryPrefsKey = nameof(NewGraph) + "." + nameof(GraphSettingsAsset) + "." + nameof(lastOpenedDirectoryPrefsKey);
         public const string isInspectorVisiblePrefsKey = nameof(NewGraph) + "." + nameof(GraphSettingsAsset) + "." + nameof(isInspectorVisiblePrefsKey);
+#if NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
+        public const string lastOpenedGraphIDEditorPrefsKey = nameof(NewGraph) + "." + nameof(GraphSettingsAsset) + "." + nameof(lastOpenedGraphIDEditorPrefsKey);
+#else
+        public const string lastOpenedGraphEditorPrefsKey = nameof(NewGraph) + "." + nameof(GraphSettingsAsset) + "." + nameof(lastOpenedGraphEditorPrefsKey);
+#endif
 
         public StyleSheet customStylesheet;
 
@@ -28,20 +32,7 @@ namespace NewGraph {
             }
         }
 
-#if NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
-        public static GraphModel LastOpenedGraphModel {
-            get {
-                if (EditorPrefs.HasKey(lastOpenedGraphEditorPrefsKey)) {
-                    int lastOpenedGraphID = EditorPrefs.GetInt(lastOpenedGraphEditorPrefsKey);
-                    return EditorUtility.InstanceIDToObject(lastOpenedGraphID) as GraphModel;
-                }
-                return null;
-            }
-            set {
-                EditorPrefs.SetInt(lastOpenedGraphEditorPrefsKey, value.GetInstanceID());
-            }
-        }
-#else
+#if !NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
         public static GraphModel LastOpenedGraphModel {
             get {
                 if (EditorPrefs.HasKey(lastOpenedGraphEditorPrefsKey)) {

--- a/Editor/Settings/GraphSettings.cs
+++ b/Editor/Settings/GraphSettings.cs
@@ -28,6 +28,20 @@ namespace NewGraph {
             }
         }
 
+#if NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
+        public static GraphModel LastOpenedGraphModel {
+            get {
+                if (EditorPrefs.HasKey(lastOpenedGraphEditorPrefsKey)) {
+                    int lastOpenedGraphID = EditorPrefs.GetInt(lastOpenedGraphEditorPrefsKey);
+                    return EditorUtility.InstanceIDToObject(lastOpenedGraphID) as GraphModel;
+                }
+                return null;
+            }
+            set {
+                EditorPrefs.SetInt(lastOpenedGraphEditorPrefsKey, value.GetInstanceID());
+            }
+        }
+#else
         public static GraphModel LastOpenedGraphModel {
             get {
                 if (EditorPrefs.HasKey(lastOpenedGraphEditorPrefsKey)) {
@@ -48,6 +62,7 @@ namespace NewGraph {
                 }
             }
         }
+#endif
 
         public string searchWindowCommandHeader = "Commands";
         public string searchWindowRootHeader = "Create Nodes";

--- a/Editor/Views/GraphModelEditor.cs
+++ b/Editor/Views/GraphModelEditor.cs
@@ -65,8 +65,10 @@ namespace NewGraph {
             GraphWindow.LoadGraph(graphModel);
         }
 
+#if !NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
         [OnOpenAsset]
         public static bool OnOpenAsset(int instanceID, int line) {
+            Debug.Log("OnOpenAsset: Graph");
             GraphModel baseGraphModel = EditorUtility.InstanceIDToObject(instanceID) as GraphModel;
             if (baseGraphModel != null) {
                 OpenGraph(baseGraphModel);
@@ -74,6 +76,7 @@ namespace NewGraph {
             }
             return false;
         }
+#endif
     }
 }
 

--- a/Editor/Views/GraphModelEditor.cs
+++ b/Editor/Views/GraphModelEditor.cs
@@ -18,7 +18,7 @@ namespace NewGraph {
             inspector.Add(openGraphButton);
             inspector.styleSheets.Add(GraphSettings.graphStylesheetVariables);
             inspector.styleSheets.Add(GraphSettings.graphStylesheet);
-
+#if NEWGRAPH_DEBUG
             listProperty = serializedObject.FindProperty(nameof(GraphModel.nodes));
             ListView listView= new ListView() {
                 showAddRemoveFooter=false,
@@ -31,7 +31,7 @@ namespace NewGraph {
                 makeItem = MakeItem
             };
             inspector.Add(listView);
-
+#endif
             return inspector;
         }
 
@@ -68,7 +68,6 @@ namespace NewGraph {
 #if !NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
         [OnOpenAsset]
         public static bool OnOpenAsset(int instanceID, int line) {
-            Debug.Log("OnOpenAsset: Graph");
             GraphModel baseGraphModel = EditorUtility.InstanceIDToObject(instanceID) as GraphModel;
             if (baseGraphModel != null) {
                 OpenGraph(baseGraphModel);

--- a/Models/GraphModel.cs
+++ b/Models/GraphModel.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using OdinSerializer.Utilities;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -15,7 +17,23 @@ namespace NewGraph {
     /// Discussion: https://forum.unity.com/threads/serialize-fields-only-in-editor.433422/
     /// </summary>
 #if NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
-    public class GraphModel : MonoBehaviour {
+    public class GraphModel : MonoBehaviour
+    {
+#if UNITY_EDITOR
+        [SerializeField]
+        private int _id;
+
+        public int ID {
+            get => _id;
+        }
+
+        private void OnValidate() {
+            if (_id == 0) {
+                _id = Guid.NewGuid().ToString("D").GetHashCode();
+            }
+        }
+#endif
+
 #else
     [CreateAssetMenu(fileName =nameof(GraphModel), menuName = nameof(GraphModel), order = 1)]
     public class GraphModel : ScriptableObject {

--- a/Models/GraphModel.cs
+++ b/Models/GraphModel.cs
@@ -14,8 +14,12 @@ namespace NewGraph {
     /// Source: https://docs.unity3d.com/2022.2/Documentation/Manual/script-Serialization.html
     /// Discussion: https://forum.unity.com/threads/serialize-fields-only-in-editor.433422/
     /// </summary>
+#if NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR
+    public class GraphModel : MonoBehaviour {
+#else
     [CreateAssetMenu(fileName =nameof(GraphModel), menuName = nameof(GraphModel), order = 1)]
     public class GraphModel : ScriptableObject {
+#endif
         /// <summary>
         /// List of all the nodes we want to work on.
         /// </summary>


### PR DESCRIPTION
Using a preprocessor symbol (NEWGRAPH_GRAPHMODEL_MONOBEHAVIOUR), these changes allow switching between a ScriptableObject- and Monobehaviour-based GraphModel.