### PR TITLE
Fix interface assignable from

### DIFF
--- a/Attributes/PortBaseAttribute.cs
+++ b/Attributes/PortBaseAttribute.cs
@@ -16,7 +16,7 @@ namespace NewGraph {
 
         private static Dictionary<ConnectionPolicy, Func<Type, Type, bool>> connectionPolicybehaviors = new Dictionary<ConnectionPolicy, Func<Type, Type, bool>>() {
             { ConnectionPolicy.Identical, (input, output) => input == output },
-            { ConnectionPolicy.IdenticalOrSubclass, (input, output) => input == output || input.IsSubclassOf(output) },
+            { ConnectionPolicy.IdenticalOrSubclass, (input, output) => input == output || input.IsSubclassOf(output) || output.IsAssignableFrom(input) },
         };
 
         /// <summary>


### PR DESCRIPTION
If you have an interface that extends INode, it would not be able to be used for port connections. This is because IsSubclassOf does not work for interfaces.