### PR TITLE
Add custom label color via NodeAttribute

### DIFF
--- a/Attributes/NodeAttribute.cs
+++ b/Attributes/NodeAttribute.cs
@@ -19,6 +19,11 @@ namespace NewGraph {
         public Color color = default;
 
         /// <summary>
+        /// Color of the propertyField's labels as a hex string, like #FFFFFFFF. Be aware: The last two characters are for alpha values!
+        /// </summary>
+        public Color labelColor = default;
+
+        /// <summary>
         /// A custom name for the node
         /// </summary>
         public string nodeName = null;
@@ -48,10 +53,11 @@ namespace NewGraph {
         /// <param name="inputPortCapacity">The maximum amount of allowed connections to the input port of this node.</param>
         /// <param name="nodeName">A custom name for the node.</param>
         /// <param name="createInputPort">The maximum amount of allowed connections to the input port of this node.</param>
-        public NodeAttribute(string color = null, string categories = "", string inputPortName = null, Capacity inputPortCapacity = Capacity.Multiple, string nodeName = null, bool createInputPort = true) {
+        public NodeAttribute(string color = null, string categories = "", string inputPortName = null, Capacity inputPortCapacity = Capacity.Multiple, string nodeName = null, bool createInputPort = true, string labelColor = null) {
             if (color != null) {
                 ColorUtility.TryParseHtmlString(color, out this.color);
             }
+            ColorUtility.TryParseHtmlString(labelColor != null ? labelColor : "#B2B2B2", out this.labelColor);
             if (nodeName != null) {
                 this.nodeName = nodeName;
             }

--- a/Editor/Controllers/NodeController.cs
+++ b/Editor/Controllers/NodeController.cs
@@ -31,7 +31,7 @@ namespace NewGraph {
             this.nodeDataProperty = nodeItem.GetSpecificSerializedProperty();
             this.propertyBag = PropertyBag.GetCachedOrCreate(nodeItem.nodeAttribute, nodeItem.nodeType, nodeDataProperty);
             this.serializedObject = graphController.graphData.SerializedGraphData;
-            this.nodeView = new NodeView(this, nodeItem.nodeAttribute.color);
+            this.nodeView = new NodeView(this, nodeItem.nodeAttribute.color, nodeItem.nodeAttribute.labelColor);
 
             string name = nodeItem.GetName();
             if (string.IsNullOrEmpty(name)) {

--- a/Editor/Views/NodeView.cs
+++ b/Editor/Views/NodeView.cs
@@ -15,6 +15,7 @@ namespace NewGraph {
         private ReactiveSettings reactiveSettings;
         public List<EditableLabelElement> editableLabels = new List<EditableLabelElement>();
         public Color nodeColor;
+        public Color labelColor;
         public bool shouldSetBackgroundColor = true;
         private bool hasInspectorProperty = false;
 
@@ -24,9 +25,10 @@ namespace NewGraph {
         public List<PortListView> portLists = new List<PortListView>();
         public List<Foldout> foldouts = new List<Foldout>();
 
-        public NodeView(NodeController controller, Color nodeColor) {
+        public NodeView(NodeController controller, Color nodeColor, Color labelColor) {
             this.controller = controller;
             this.nodeColor = nodeColor;
+            this.labelColor = labelColor;
         }
 
         private void ColorizeBackground() {
@@ -34,6 +36,16 @@ namespace NewGraph {
                 style.backgroundColor = nodeColor;
             } else {
                 style.backgroundColor = Settings.defaultNodeColor;
+            }
+        }
+
+        private void ColorizeLabels()
+        {
+            foreach (var field in controller.nodeView.ExtensionContainer.Children())
+            {
+                Label label = field.Q<Label>(className: "unity-base-field__label");
+                if (label != null)
+                    label.style.color = labelColor;
             }
         }
 
@@ -83,6 +95,8 @@ namespace NewGraph {
             controller.nodeItem.CleanupFoldoutStates();
 
             BindUI(controller.GetSerializedObject());
+
+            ColorizeLabels();
         }
 
         public void RebuildPortListView(PortListView view) {


### PR DESCRIPTION
Enables you to set other color to PropertyField's Label's text, like:

```c#
Node("#16A085", labelColor: "#000000")
```

![image](https://github.com/user-attachments/assets/afdbcc80-70f5-4378-993d-99b15939ec65)

It make a lot easier better colors to read text inside the Node's ExtensionContainer.